### PR TITLE
addition and conventions and yml fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 env:
   DOTNET_VERSION: '8.0.x'
 # Cancel in‑progress runs when new commits are pushed
@@ -119,8 +118,9 @@ jobs:
           LATEST_TAG=$(git tag -l "0.1.*-preview" | sort -V | tail -n1)
 
           if [ -z "$LATEST_TAG" ]; then
-            # No tags exist, start with 0.1.1-preview
-            NEW_VERSION="0.1.1-preview"
+            # No tags exist, but there's already a 0.1.1-preview published manually
+            # Start with 0.1.2-preview
+            NEW_VERSION="0.1.2-preview"
           else
             # Extract patch version, increment, and append -preview
             PATCH_VERSION=$(echo $LATEST_TAG | cut -d'.' -f3 | cut -d'-' -f1)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,87 @@ services.AddDbContext<MyParquetContext>(options =>
 - Query tracking is disabled by default for better performance (can be overridden via `NoTracking = false`)
 - All DuckDB dependencies are automatically registered when using the extensions
 
+## Custom Conventions (Optional)
+
+The library includes optional EF Core conventions that can simplify your model configuration by automatically mapping entity and property names directly to table and column names.
+
+### Available Conventions
+
+1. **EntityNameAsTableNameConvention**: Automatically sets table names to match entity class names
+2. **PropertyNameAsColumnNameConvention**: Automatically sets column names to match property names
+3. **CustomConventionSetBuilder**: Applies both conventions together
+
+### Usage
+
+```csharp
+using EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+
+// Option 1: Apply conventions when configuring DbContext
+var options = new DbContextOptionsBuilder<MyDbContext>()
+    .UseDuckDb(opts =>
+    {
+        opts.ConnectionString = "DataSource=mydb.duckdb";
+    })
+    .ReplaceService<IProviderConventionSetBuilder, CustomConventionSetBuilder>()
+    .Options;
+
+// Option 2: Apply in dependency injection
+services.AddDbContext<MyDbContext>(options =>
+{
+    options.UseDuckDb(opts =>
+    {
+        opts.ConnectionString = configuration["DuckDb:ConnectionString"];
+    })
+    .ReplaceService<IProviderConventionSetBuilder, CustomConventionSetBuilder>();
+});
+```
+
+### Benefits
+
+- **Reduced Boilerplate**: No need to manually configure table and column names
+- **Consistency**: Ensures naming conventions are applied uniformly across your model
+- **DuckDB Compatibility**: Particularly useful when working with DuckDB views or Parquet files where column names must match exactly
+- **Simplified Migrations**: When entity/property names match database schema, there's less configuration needed
+
+### Example Scenario
+
+Without conventions:
+```csharp
+public class CustomerOrder
+{
+    public int OrderId { get; set; }
+    public string CustomerName { get; set; }
+}
+
+// Requires manual configuration
+modelBuilder.Entity<CustomerOrder>()
+    .ToTable("CustomerOrder")
+    .Property(e => e.CustomerName)
+    .HasColumnName("CustomerName");
+```
+
+With conventions (automatically applied):
+```csharp
+public class CustomerOrder
+{
+    public int OrderId { get; set; }
+    public string CustomerName { get; set; }
+}
+// No additional configuration needed!
+```
+
+### When to Use
+
+These conventions are particularly helpful when:
+- Your entity and property names already match your database schema
+- You're working with existing Parquet files or DuckDB views
+- You want to reduce EF Core configuration code
+- You prefer convention over configuration approach
+
+> **Note**: These conventions are optional. If you need different table/column names than your entity/property names, simply don't apply the conventions and use standard EF Core configuration.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/Source/DuckDb/Conventions/CustomConventionSetBuilder.cs
+++ b/Source/DuckDb/Conventions/CustomConventionSetBuilder.cs
@@ -1,0 +1,25 @@
+﻿// OPTIONAL: Custom convention set builder that applies EntityNameAsTableNameConvention and PropertyNameAsColumnNameConvention.
+// Usage example:
+// DbContextOptionsBuilder<PlexosInputDbContext> contextBuilder = new DbContextOptionsBuilder<PlexosInputDbContext>();
+// contextBuilder.ReplaceService<IProviderConventionSetBuilder, CustomConventionSetBuilder>();
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions
+{
+    public class CustomConventionSetBuilder : SqlServerConventionSetBuilder
+    {
+        public CustomConventionSetBuilder(ProviderConventionSetBuilderDependencies dependencies, RelationalConventionSetBuilderDependencies relationalDependencies, ISqlGenerationHelper sqlGenerationHelper) : base(dependencies, relationalDependencies, sqlGenerationHelper)
+        {
+        }
+        public override ConventionSet CreateConventionSet()
+        {
+            var set = base.CreateConventionSet();
+            set.EntityTypeAddedConventions.Add(new EntityNameAsTableNameConvention());
+            set.PropertyAddedConventions.Add(new PropertyNameAsColumnNameConvention());
+            return set;
+
+        }
+    }
+}

--- a/Source/DuckDb/Conventions/EntityNameAsTableNameConvention.cs
+++ b/Source/DuckDb/Conventions/EntityNameAsTableNameConvention.cs
@@ -1,0 +1,21 @@
+// OPTIONAL: This convention automatically sets table names to match entity names.
+// Usage example:
+// DbContextOptionsBuilder<PlexosInputDbContext> contextBuilder = new DbContextOptionsBuilder<PlexosInputDbContext>();
+// contextBuilder.ReplaceService<IProviderConventionSetBuilder, CustomConventionSetBuilder>();
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions
+{
+    public class EntityNameAsTableNameConvention : IEntityTypeAddedConvention
+    {
+        public void ProcessEntityTypeAdded(
+            IConventionEntityTypeBuilder entityTypeBuilder,
+            IConventionContext<IConventionEntityTypeBuilder> context)
+        {
+
+            entityTypeBuilder.ToTable(entityTypeBuilder.Metadata.ShortName(), fromDataAnnotation: true);
+        }
+    }
+}

--- a/Source/DuckDb/Conventions/PropertyNameAsColumnNameConvention.cs
+++ b/Source/DuckDb/Conventions/PropertyNameAsColumnNameConvention.cs
@@ -1,0 +1,21 @@
+﻿// OPTIONAL: This convention automatically sets column names to match property names.
+// Usage example:
+// DbContextOptionsBuilder<PlexosInputDbContext> contextBuilder = new DbContextOptionsBuilder<PlexosInputDbContext>();
+// contextBuilder.ReplaceService<IProviderConventionSetBuilder, CustomConventionSetBuilder>();
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions
+{
+    public class PropertyNameAsColumnNameConvention : IPropertyAddedConvention
+    {
+        public void ProcessPropertyAdded(
+        IConventionPropertyBuilder propertyBuilder,
+        IConventionContext<IConventionPropertyBuilder> context)
+        {
+            propertyBuilder.HasColumnName(propertyBuilder.Metadata.Name, fromDataAnnotation: true);
+        }
+
+    }
+}


### PR DESCRIPTION
# Pull Request: CI/CD Workflow Updates and Documentation Enhancements

## Summary

This PR updates the CI/CD workflows to trigger only on post-merge events, fixes namespace inconsistencies, and adds comprehensive documentation for the Custom Conventions feature.

## Changes Made

### 1. CI/CD Workflow Improvements

#### CI Workflow (`ci.yml`)
- **Modified trigger behavior**: Now only triggers on push to main branch (post-merge), removing pull_request triggers
- **Added manual workflow dispatch**: Can now be triggered manually via GitHub Actions UI
- **Updated version logic**: Adjusted to start from `0.1.2-preview` since `0.1.1-preview` was already published manually
- **Automatic tag creation**: Workflow creates and pushes Git tags automatically

#### NuGet Release Workflow (`nuget-release.yml`)
- Already configured correctly to:
  - Trigger automatically after successful CI workflow completion
  - Support manual workflow dispatch with CI run ID input
  - Verify packages and Git tags before publishing to NuGet.org

### 2. Namespace Standardization

Updated all files in `Source/DuckDb/Conventions/` folder to use consistent namespace:
- **From**: `EnergyExemplar.Plexos.ParquetQueryManager.Conventions`
- **To**: `EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions`

This aligns with the namespace pattern used in `Source/DuckDb/Interceptors/` for consistency across the codebase.

**Files updated:**
- `CustomConventionSetBuilder.cs`
- `EntityNameAsTableNameConvention.cs`
- `PropertyNameAsColumnNameConvention.cs`

### 3. Documentation Enhancements

Added comprehensive documentation for the Custom Conventions feature in `README.md`:
- Detailed explanation of available conventions
- Usage examples with `ReplaceService<IProviderConventionSetBuilder, CustomConventionSetBuilder>()`
- Benefits of using conventions (reduced boilerplate, consistency, DuckDB compatibility)
- Before/after comparison examples
- Guidance on when to use these conventions

## Workflow Behavior After This PR

1. **Automatic Flow**:
   - Push to main (after PR merge) → CI workflow runs → Creates tag `0.1.2-preview` → Builds and creates NuGet package → NuGet Release workflow triggers → Publishes to NuGet.org

2. **Manual Flow**:
   - Both workflows can be triggered manually from GitHub Actions UI
   - CI workflow: Direct manual trigger
   - NuGet Release: Manual trigger with CI run ID parameter

## Testing Checklist

- [ ] CI workflow triggers only on push to main branch
- [ ] Manual workflow dispatch works for both workflows
- [ ] Version increments correctly from `0.1.1-preview` to `0.1.2-preview`
- [ ] Git tags are created and pushed successfully
- [ ] NuGet package is published with correct version
- [ ] Custom Conventions work with updated namespaces
- [ ] Documentation is clear and examples are correct

## Breaking Changes

None - all changes are backwards compatible.

## Notes

- The first run after merging will create version `0.1.2-preview` (skipping the already published `0.1.1-preview`)
- Subsequent runs will increment the patch version: `0.1.3-preview`, `0.1.4-preview`, etc.
- The Custom Conventions feature is optional and doesn't affect existing implementations