### PR TITLE
Add DateTimeNow to CurrentTimestamp SQL rewrite rule and tests

### DIFF
--- a/Source/DuckDb/Internals/RewritePipeline.cs
+++ b/Source/DuckDb/Internals/RewritePipeline.cs
@@ -29,7 +29,8 @@ namespace EnergyExemplar.Extensions.DuckDb.Internals
             DuckSqlRules.RandomFuncAlias,
             DuckSqlRules.BitwiseAndToLogicalAnd,
             DuckSqlRules.BitwiseOrToLogicalOr,
-            DuckSqlRules.LimitMinusOneToOffset
+            DuckSqlRules.LimitMinusOneToOffset,
+            DuckSqlRules.DateTimeNowToCurrentTimestamp
         });
     }
 }

--- a/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
+++ b/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
@@ -11,9 +11,9 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>EnergyExemplar.EntityFrameworkCore.DuckDb</PackageId>
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <Version>1.0.1</Version>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
     <Title>DuckDB Entity Framework Core Integration</Title>
     <Description>Seamless integration between Entity Framework Core and DuckDB, providing significant performance improvements for analytical queries with a simple, developer-friendly API.</Description>
     <Authors>Energy Exemplar Pty Ltd</Authors>


### PR DESCRIPTION
# Fix DateTime.Now Support in LINQ Queries (#24)

## Summary
This PR fixes the issue where using `DateTime.Now` directly in LINQ queries causes a DuckDB Binder Error. The fix adds a SQL rewrite rule to convert SQLite's `strftime()` function calls to DuckDB's `CURRENT_TIMESTAMP`.

## Problem
Previously, queries like this would fail:
```csharp
var items = await db.User.Where(x => x.CreateTime < DateTime.Now).ToListAsync();
```

With error:
```
Binder Error: Could not choose a best candidate function for the function call "strftime(STRING_LITERAL, STRING_LITERAL)"
```

The workaround was to assign `DateTime.Now` to a variable first, which was inconvenient.

## Solution
Added a new SQL rewrite rule that detects and transforms SQLite's DateTime patterns:
- `strftime('%Y-%m-%d %H:%M:%f', 'now', 'localtime')` → `CURRENT_TIMESTAMP`
- `strftime('%Y-%m-%d %H:%M:%f', 'now')` → `CURRENT_TIMESTAMP`
- Also handles EF Core's rtrim-wrapped patterns: `rtrim(rtrim(strftime(...), '0'), '.')`

## Changes
- ✅ Added `DateTimeNowToCurrentTimestamp` rewrite rule in `DuckSqlRules.cs`
- ✅ Registered the rule in `RewritePipeline.cs`
- ✅ Added comprehensive unit tests (7 new tests)
- ✅ Added integration tests (3 new tests)
- ✅ Version bumped to 1.0.1
- ✅ All 58 tests passing

## Testing
The fix includes extensive test coverage:
- Pattern matching tests for various `strftime` formats
- Case-insensitive matching tests
- Tests for rtrim-wrapped patterns (EF Core's fractional seconds handling)
- Integration tests with actual EF Core queries
- Tests for both `DateTime.Now` and `DateTime.UtcNow`

## Breaking Changes
None. This is a backward-compatible fix.

## Acknowledgments
Thanks to @netnr for reporting this issue and providing clear reproduction steps. The collaborative effort helped ensure we covered all the edge cases that EF Core generates.

## Closes
Fixes #24