### PR TITLE
net10 version upgrades

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -5,6 +5,12 @@ on:
     types: [opened, synchronize, reopened]
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write
+
 env:
   DOTNET_VERSION: '8.0.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
     branches: [ main ]
   workflow_dispatch:
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_NET8_VERSION: '8.0.x'
+  DOTNET_NET10_VERSION: '10.0.x'
 # Cancel in‑progress runs when new commits are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +26,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            ${{ env.DOTNET_NET8_VERSION }}
+            ${{ env.DOTNET_NET10_VERSION }}
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -67,7 +70,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            ${{ env.DOTNET_NET8_VERSION }}
+            ${{ env.DOTNET_NET10_VERSION }}
       - name: Restore dependencies
         run: dotnet restore --verbosity normal
         working-directory: ./Source
@@ -109,41 +114,46 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            ${{ env.DOTNET_NET8_VERSION }}
+            ${{ env.DOTNET_NET10_VERSION }}
 
-      - name: Get latest version tag
+      - name: Get latest version tagss
         id: get_version
         run: |
-          # Get the latest semantic version tag
-          LATEST_TAG=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
-
-          if [ -z "$LATEST_TAG" ]; then
-            # No stable tags exist, start with 1.0.0
-            NEW_VERSION="1.0.0"
+          # net8: find the latest 8.0.x tag and increment patch
+          LATEST_NET8=$(git tag -l | grep -E '^8\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+          if [ -z "$LATEST_NET8" ]; then
+            NET8_VERSION="8.0.0"
           else
-            # Parse semantic version
-            MAJOR=$(echo $LATEST_TAG | cut -d'.' -f1)
-            MINOR=$(echo $LATEST_TAG | cut -d'.' -f2)
-            PATCH=$(echo $LATEST_TAG | cut -d'.' -f3)
-
-            # Increment patch version for automatic releases
-            NEW_PATCH=$((PATCH + 1))
-            NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+            PATCH=$(echo $LATEST_NET8 | cut -d'.' -f3)
+            NET8_VERSION="8.0.$((PATCH + 1))"
           fi
 
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Latest tag: $LATEST_TAG"
-          echo "New version: $NEW_VERSION"
+          # net10: find the latest 10.0.x tag and increment patch
+          LATEST_NET10=$(git tag -l | grep -E '^10\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)
+          if [ -z "$LATEST_NET10" ]; then
+            NET10_VERSION="10.0.0"
+          else
+            PATCH=$(echo $LATEST_NET10 | cut -d'.' -f3)
+            NET10_VERSION="10.0.$((PATCH + 1))"
+          fi
 
-      - name: Create and push Git tag
+          echo "net8_version=$NET8_VERSION" >> $GITHUB_OUTPUT
+          echo "net10_version=$NET10_VERSION" >> $GITHUB_OUTPUT
+          echo "Net8 version: $NET8_VERSION"
+          echo "Net10 version: $NET10_VERSION"
+
+      - name: Create and push Git tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.get_version.outputs.new_version }}
-          git push origin ${{ steps.get_version.outputs.new_version }}
+          git tag ${{ steps.get_version.outputs.net8_version }}
+          git tag ${{ steps.get_version.outputs.net10_version }}
+          git push origin ${{ steps.get_version.outputs.net8_version }}
+          git push origin ${{ steps.get_version.outputs.net10_version }}
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -155,10 +165,6 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore
-        working-directory: ./Source
-
-      - name: Build Release
-        run: dotnet build --no-restore --configuration Release
         working-directory: ./Source
 
       - name: Clean workspace of existing packages
@@ -173,18 +179,34 @@ jobs:
           # Remove any test-nuget-packages directory to prevent it from being included
           find . -type d -name "test-nuget-packages" -exec rm -rf {} +
       
-      - name: Pack NuGet package
+      - name: Pack NuGet packages
         run: |
-          # Use a relative path that will work in the GitHub Actions environment
+          # Pack net8.0 with 8.0.x versioning (includes native binaries)
           dotnet pack ./Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj \
-            --no-build \
+            --no-restore \
             --configuration Release \
+            --framework net8.0 \
             --output ./nuget-packages \
-            /p:Version=${{ steps.get_version.outputs.new_version }} \
+            /p:Version=${{ steps.get_version.outputs.net8_version }} \
+            /p:FileVersion=${{ steps.get_version.outputs.net8_version }}.1 \
+            /p:AssemblyVersion=${{ steps.get_version.outputs.net8_version }}.1 \
             /p:IsPackable=true \
             /p:IncludeSymbols=true \
             /p:NoWarn=NU5105
-          
+
+          # Pack net10.0 with 10.0.x versioning (binaries supplied by consumer)
+          dotnet pack ./Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj \
+            --no-restore \
+            --configuration Release \
+            --framework net10.0 \
+            --output ./nuget-packages \
+            /p:Version=${{ steps.get_version.outputs.net10_version }} \
+            /p:FileVersion=${{ steps.get_version.outputs.net10_version }}.1 \
+            /p:AssemblyVersion=${{ steps.get_version.outputs.net10_version }}.1 \
+            /p:IsPackable=true \
+            /p:IncludeSymbols=true \
+            /p:NoWarn=NU5105
+
           # Extra safety: remove any test packages that might have been created
           find ./nuget-packages \( -name "*test*.nupkg" -o -name "*.Test*.nupkg" -o -name "*.Tests*.nupkg" \) -type f -delete
 
@@ -203,24 +225,29 @@ jobs:
           echo "All packages in output directory:"
           find ./nuget-packages -name "*.nupkg" -o -name "*.snupkg" -type f
           
-          # Verify we have exactly the expected package(s)
-          EXPECTED_PACKAGE="EnergyExemplar.EntityFrameworkCore.DuckDb.${{ steps.get_version.outputs.new_version }}.nupkg"
-          
-          # Check for presence of main package
-          if [ ! -f "./nuget-packages/$EXPECTED_PACKAGE" ]; then
-            echo "Error: Main package not found: $EXPECTED_PACKAGE"
+          # Verify we have the expected net8 and net10 packages
+          NET8_PKG="EnergyExemplar.EntityFrameworkCore.DuckDb.${{ steps.get_version.outputs.net8_version }}.nupkg"
+          NET10_PKG="EnergyExemplar.EntityFrameworkCore.DuckDb.${{ steps.get_version.outputs.net10_version }}.nupkg"
+
+          if [ ! -f "./nuget-packages/$NET8_PKG" ]; then
+            echo "Error: net8 package not found: $NET8_PKG"
             exit 1
           fi
-          
+          if [ ! -f "./nuget-packages/$NET10_PKG" ]; then
+            echo "Error: net10 package not found: $NET10_PKG"
+            exit 1
+          fi
+
           # Count total packages (including symbols)
           PACKAGE_COUNT=$(find ./nuget-packages -name "*.nupkg" -o -name "*.snupkg" -type f | wc -l)
-          
+
           echo "Found $PACKAGE_COUNT package(s) in output directory"
-          echo "Main package: $EXPECTED_PACKAGE ✅"
-          
-          # Allow 1-2 packages (main + optional symbols)
-          if [ "$PACKAGE_COUNT" -lt 1 ] || [ "$PACKAGE_COUNT" -gt 2 ]; then
-            echo "Error: Expected 1-2 packages (main + optional symbols), found $PACKAGE_COUNT"
+          echo "Net8 package:  $NET8_PKG ✅"
+          echo "Net10 package: $NET10_PKG ✅"
+
+          # Allow 2-4 packages (net8 main + net10 main + optional symbols for each)
+          if [ "$PACKAGE_COUNT" -lt 2 ] || [ "$PACKAGE_COUNT" -gt 4 ]; then
+            echo "Error: Expected 2-4 packages (net8 + net10 main + optional symbols), found $PACKAGE_COUNT"
             exit 1
           fi
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,14 +179,17 @@ jobs:
           # Remove any test-nuget-packages directory to prevent it from being included
           find . -type d -name "test-nuget-packages" -exec rm -rf {} +
       
+      - name: Build Release
+        run: dotnet build ./Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj --no-restore --configuration Release
+
       - name: Pack NuGet packages
         run: |
           # Pack net8.0 with 8.0.x versioning (includes native binaries)
           dotnet pack ./Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj \
-            --no-restore \
+            --no-build \
             --configuration Release \
-            --framework net8.0 \
             --output ./nuget-packages \
+            /p:TargetFrameworks=net8.0 \
             /p:Version=${{ steps.get_version.outputs.net8_version }} \
             /p:FileVersion=${{ steps.get_version.outputs.net8_version }}.1 \
             /p:AssemblyVersion=${{ steps.get_version.outputs.net8_version }}.1 \
@@ -196,10 +199,10 @@ jobs:
 
           # Pack net10.0 with 10.0.x versioning (binaries supplied by consumer)
           dotnet pack ./Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj \
-            --no-restore \
+            --no-build \
             --configuration Release \
-            --framework net10.0 \
             --output ./nuget-packages \
+            /p:TargetFrameworks=net10.0 \
             /p:Version=${{ steps.get_version.outputs.net10_version }} \
             /p:FileVersion=${{ steps.get_version.outputs.net10_version }}.1 \
             /p:AssemblyVersion=${{ steps.get_version.outputs.net10_version }}.1 \

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -112,8 +112,8 @@ jobs:
         main_packages=$(find . -name "*.nupkg" -type f ! -name "*.symbols.nupkg")
         package_count=$(echo "$main_packages" | wc -l)
         
-        if [ "$package_count" -ne 1 ]; then
-          echo "Error: Expected exactly 1 main NuGet package, found $package_count"
+        if [ "$package_count" -ne 2 ]; then
+          echo "Error: Expected exactly 2 main NuGet packages (net8 and net10), found $package_count"
           echo "Main packages found:"
           echo "$main_packages"
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /Source/bin/Release
 /Tests/bin/Release/net8.0
 /Tests/TestResults/b14ec04d-7304-467a-88c3-54469dd7212c/coverage.cobertura.xml
+/Tests/bin/Debug/net10.0

--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,10 @@
 /obj
 /bin/Debug
 /Source/.vs/EnergyExemplar.Extensions
-/Source/bin/Debug
+/Source/bin
 /Source/obj
-/Tests/bin/Debug/net8.0
+/Tests/bin
 /Tests/obj
 /Source/.vs/ProjectEvaluation
 /Source/.vs/EnergyExemplar.EFCore.Duckdb.Extensions
-/Source/bin/Release
-/Tests/bin/Release/net8.0
-/Tests/TestResults/b14ec04d-7304-467a-88c3-54469dd7212c/coverage.cobertura.xml
-/Tests/bin/Debug/net10.0
+/Tests/TestResults

--- a/README.md
+++ b/README.md
@@ -31,12 +31,59 @@ DuckDB's columnar storage and vectorized execution engine provide substantial pe
 
 ## Installation
 
-Ensure you have the necessary NuGet packages:
+Add the main package to your project:
+
 ```xml
-<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-<PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
+<PackageReference Include="EnergyExemplar.EntityFrameworkCore.DuckDb" Version="*" />
 ```
+
+### Native Binary Dependencies
+
+The native library requirements differ by target framework:
+
+#### .NET 8 (`net8.0`)
+
+The `net8.0` build of this package **includes** the native DuckDB and SQLite binaries transitively via `DuckDB.NET.Data.Full` and `SourceGear.sqlite3`. No additional packages are required.
+
+#### .NET 10 (`net10.0`)
+
+The `net10.0` build does **not** include native binaries. You must supply them explicitly.
+
+**DuckDB native binaries** — add one of:
+```xml
+<PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+```
+
+**SQLite native binaries** — add one of:
+- `Microsoft.EntityFrameworkCore.Sqlite` (the full package, not `.Core`) — if you are already referencing it in your project, its transitive dependency on `SQLitePCLRaw.bundle_e_sqlite3` covers SQLite binaries automatically.
+- Or add a standalone SQLite bundle explicitly:
+```xml
+<PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
+```
+
+> **Why the difference?** The `net8.0` build bundles binaries to avoid breaking existing consumers. The `net10.0` build intentionally omits them so you can choose the binary packages appropriate for your platform and deployment environment.
+
+## Versioning
+
+Starting with version `10.0.0`, this package adopts a versioning scheme aligned with the .NET and EF Core major version it targets:
+
+| Package version | Target framework | EF Core version |
+|-----------------|-----------------|-----------------|
+| `10.0.x`        | `net10.0`       | `10.x`          |
+| `8.0.x`         | `net8.0`        | `8.x`           |
+| `1.x` (legacy)  | `net8.0`        | `8.x`           |
+
+When referencing the package, pin to the major version that matches your target framework:
+
+```xml
+<!-- .NET 10 projects -->
+<PackageReference Include="EnergyExemplar.EntityFrameworkCore.DuckDb" Version="10.0.*" />
+
+<!-- .NET 8 projects -->
+<PackageReference Include="EnergyExemplar.EntityFrameworkCore.DuckDb" Version="8.0.*" />
+```
+
+> **Upgrading from 1.x?** If you are currently on a `1.x` release (net8), move to the `8.0.x` range. No API changes are required — only the version pin needs updating.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 This provides a seamless integration between Entity Framework Core and DuckDB, allowing you to use DuckDB as your database while maintaining the familiar EF Core API.
 
+> **⚠️ Native library dependencies not included**
+> This package does **not** include the DuckDB or SQLite native libraries. You must add the appropriate driver packages to your project separately — see the [Installation](#installation) section below.
+
 ## Features
 
 - **Simple API**: Just use `UseDuckDb()` similar to `UseSqlite()` or `UseSqlServer()`
@@ -30,9 +33,9 @@ DuckDB's columnar storage and vectorized execution engine provide substantial pe
 
 Ensure you have the necessary NuGet packages:
 ```xml
-<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-<PackageReference Include="DuckDB.NET.Data.Full" Version="1.3.2" />
+<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+<PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
 ```
 
 ## Basic Usage

--- a/Source/DuckDb/Conventions/CustomConventionSetBuilder.cs
+++ b/Source/DuckDb/Conventions/CustomConventionSetBuilder.cs
@@ -10,7 +10,11 @@ namespace EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions
 {
     public class CustomConventionSetBuilder : SqlServerConventionSetBuilder
     {
-        public CustomConventionSetBuilder(ProviderConventionSetBuilderDependencies dependencies, RelationalConventionSetBuilderDependencies relationalDependencies, ISqlGenerationHelper sqlGenerationHelper) : base(dependencies, relationalDependencies, sqlGenerationHelper)
+        public CustomConventionSetBuilder(
+            ProviderConventionSetBuilderDependencies dependencies, 
+            RelationalConventionSetBuilderDependencies relationalDependencies, 
+            ISqlGenerationHelper sqlGenerationHelper) : 
+            base(dependencies, relationalDependencies, sqlGenerationHelper)
         {
         }
         public override ConventionSet CreateConventionSet()
@@ -19,7 +23,6 @@ namespace EnergyExemplar.EntityFrameworkCore.DuckDb.Conventions
             set.EntityTypeAddedConventions.Add(new EntityNameAsTableNameConvention());
             set.PropertyAddedConventions.Add(new PropertyNameAsColumnNameConvention());
             return set;
-
         }
     }
 }

--- a/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
+++ b/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
@@ -11,15 +11,15 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>EnergyExemplar.EntityFrameworkCore.DuckDb</PackageId>
-    <Version>1.0.1</Version>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <Version>10.0.0</Version>
+    <AssemblyVersion>10.0.0.0</AssemblyVersion>
+    <FileVersion>10.0.0.0</FileVersion>
     <Title>DuckDB Entity Framework Core Integration</Title>
     <Description>Seamless integration between Entity Framework Core and DuckDB, providing significant performance improvements for analytical queries with a simple, developer-friendly API.</Description>
     <Authors>Energy Exemplar Pty Ltd</Authors>
     <Company>Energy Exemplar Pty Ltd</Company>
     <Product>EnergyExemplar DuckDB Extensions</Product>
-    <Copyright>Copyright (c) 2025 Energy Exemplar Pty Ltd</Copyright>
+    <Copyright>Copyright (c) 2026 Energy Exemplar Pty Ltd</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/EnergyExemplar/EnergyExemplar.EFCore.Duckdb.Extensions</PackageProjectUrl>
@@ -35,16 +35,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-  </ItemGroup>
-
-  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Tests</_Parameter1>
     </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
+++ b/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
@@ -11,9 +11,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>EnergyExemplar.EntityFrameworkCore.DuckDb</PackageId>
-    <Version>10.0.0</Version>
-    <AssemblyVersion>10.0.0.0</AssemblyVersion>
-    <FileVersion>10.0.0.0</FileVersion>
+   
     <Title>DuckDB Entity Framework Core Integration</Title>
     <Description>Seamless integration between Entity Framework Core and DuckDB, providing significant performance improvements for analytical queries with a simple, developer-friendly API. Note: this package does not include the DuckDB or SQLite native libraries — you must add the appropriate DuckDB.NET or SQLite driver package separately.</Description>
     <Authors>Energy Exemplar Pty Ltd</Authors>
@@ -42,11 +40,24 @@
 
   <ItemGroup>
     <PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
+	  <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
+++ b/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
@@ -15,7 +15,7 @@
     <AssemblyVersion>10.0.0.0</AssemblyVersion>
     <FileVersion>10.0.0.0</FileVersion>
     <Title>DuckDB Entity Framework Core Integration</Title>
-    <Description>Seamless integration between Entity Framework Core and DuckDB, providing significant performance improvements for analytical queries with a simple, developer-friendly API.</Description>
+    <Description>Seamless integration between Entity Framework Core and DuckDB, providing significant performance improvements for analytical queries with a simple, developer-friendly API. Note: this package does not include the DuckDB or SQLite native libraries — you must add the appropriate DuckDB.NET or SQLite driver package separately.</Description>
     <Authors>Energy Exemplar Pty Ltd</Authors>
     <Company>Energy Exemplar Pty Ltd</Company>
     <Product>EnergyExemplar DuckDB Extensions</Product>

--- a/Source/EnergyExemplar.EFCore.Duckdb.Extensions.sln
+++ b/Source/EnergyExemplar.EFCore.Duckdb.Extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11520.95 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnergyExemplar.EFCore.Duckdb.Extensions", "EnergyExemplar.EFCore.Duckdb.Extensions.csproj", "{3D4DBD91-DB52-41A0-A95E-91BD3A7CC11E}"
 EndProject

--- a/Tests/DuckDb/DbDataReaderCustomCastingTests.cs
+++ b/Tests/DuckDb/DbDataReaderCustomCastingTests.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Linq;
 using DuckDB.NET.Data;
 using EnergyExemplar.EntityFrameworkCore.DuckDb.Interceptors;
-using NUnit.Framework;
 
 namespace Tests.DuckDb
 {

--- a/Tests/DuckDb/DuckDbExtensionsTests.cs
+++ b/Tests/DuckDb/DuckDbExtensionsTests.cs
@@ -1,10 +1,6 @@
-using System;
-using System.IO;
-using System.Linq;
 using EnergyExemplar.EntityFrameworkCore.DuckDb;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System.Reflection;
 
 namespace Tests.DuckDb

--- a/Tests/DuckDb/RewritePipelineTests.cs
+++ b/Tests/DuckDb/RewritePipelineTests.cs
@@ -1,5 +1,4 @@
 using EnergyExemplar.Extensions.DuckDb.Internals;
-using NUnit.Framework;
 
 namespace Tests.DuckDb
 {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,21 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+	<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.27" />
     <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change better allows downstream integrations to reference packages with sqlite/duckdb binaries without conflicts.

- Upgrades to the net10 and upgrades packages to the latest net 10 versions.
  - Also update to the package version to be in sync with Microsoft package versions for net 10
- Removes package references that include binaries in the output
- Unit tests passing