### PR TITLE
Upgrade DuckDB.NET 1.5.2 -> 1.5.5 and guard #332 reader regression

### DIFF
--- a/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
+++ b/Source/EnergyExemplar.EFCore.Duckdb.Extensions.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DuckDB.NET.Data" Version="1.5.2" />
+    <PackageReference Include="DuckDB.NET.Data" Version="1.5.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.27" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.27" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
-	  <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+	  <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.5" />
     <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
   </ItemGroup>
 

--- a/Tests/DuckDb/DbDataReaderCustomCastingTests.cs
+++ b/Tests/DuckDb/DbDataReaderCustomCastingTests.cs
@@ -113,5 +113,53 @@ namespace Tests.DuckDb
                 Assert.Throws<FormatException>(() => reader.GetDecimal(3)); // 'invalid' string should throw
             });
         }
+
+        // Regression guard for DuckDB.NET issue #332 (fixed in 1.5.3): reading column
+        // metadata after a result set was exhausted threw IndexOutOfRangeException on
+        // 1.5.0–1.5.2, because InitNextReader() cleared the vector readers before probing
+        // for another result set while FieldCount still held the previous column count.
+        // EF Core materialization and DataTable.Load drive exactly this path — read every
+        // row, call NextResult() to probe for more result sets, then inspect the schema —
+        // and this library's DbDataReaderCustomCasting delegates every one of these members.
+        [Test]
+        public void Decorator_ReadsColumnMetadata_AfterResultExhausted()
+        {
+            using var conn = CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1 AS id, 'a' AS name";
+            using var reader = new DbDataReaderCustomCasting(cmd.ExecuteReader());
+
+            while (reader.Read()) { }                     // exhaust all rows
+            Assert.That(reader.NextResult(), Is.False);    // probe for further result sets
+
+            // These delegated members are the exact frames in issue #332's stack trace.
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.FieldCount, Is.EqualTo(2));
+                Assert.That(reader.GetName(0), Is.EqualTo("id"));
+                Assert.That(reader.GetName(1), Is.EqualTo("name"));
+                Assert.That(reader.GetFieldType(0), Is.EqualTo(typeof(int)));
+                Assert.That(reader.GetDataTypeName(1), Is.Not.Null);
+            });
+        }
+
+        // Companion to the above at the raw provider surface — mirrors the exact call in
+        // issue #332 (GetSchemaTable). The decorator does not override GetSchemaTable, so
+        // this asserts against the underlying DuckDBDataReader the library wraps.
+        [Test]
+        public void RawReader_GetSchemaTable_AfterResultExhausted_DoesNotThrow()
+        {
+            using var conn = CreateConnection();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1 AS id, 'a' AS name";
+            using var reader = cmd.ExecuteReader();
+
+            while (reader.Read()) { }
+            Assert.That(reader.NextResult(), Is.False);
+
+            var schema = reader.GetSchemaTable();
+            Assert.That(schema, Is.Not.Null);
+            Assert.That(schema!.Rows, Has.Count.EqualTo(2));
+        }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.27" />
     <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.2" />
+    <PackageReference Include="DuckDB.NET.Data.Full" Version="1.5.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
   </ItemGroup>
 


### PR DESCRIPTION
## What

Upgrades **DuckDB.NET** from **1.5.2 → 1.5.5** (latest stable) and adds regression coverage for the one client-library change that touches this package's surface.

### Version bumps (4 references)
| File | Package | TFM |
|------|---------|-----|
| `Source/…Extensions.csproj` | `DuckDB.NET.Data` | all |
| `Source/…Extensions.csproj` | `DuckDB.NET.Data.Full` | net8.0 |
| `Tests/Tests.csproj` | `DuckDB.NET.Data.Full` | net8.0 |
| `Tests/Tests.csproj` | `DuckDB.NET.Data.Full` | net10.0 |

## Why the new tests

Reviewed the DuckDB.NET client changes across 1.5.2 → 1.5.5. Most are irrelevant to an EF Core integration (appender fixes, Apache Arrow streaming, `unnest($p)` collection binding, an internal `Convert.ChangeType` fast path). **One is directly relevant:** issue [#332](https://github.com/Giorgi/DuckDB.NET/issues/332) — `IndexOutOfRangeException` when reading column metadata / `GetSchemaTable()` after a result set is exhausted. It regressed in 1.5.0, was present in 1.5.2, and was fixed in 1.5.3.

This is exactly the path EF Core materialization and `DataTable.Load` drive (read all rows → `NextResult()` → inspect schema), and this library's `DbDataReaderCustomCasting` decorator delegates every one of those members.

### Two tests added (`DbDataReaderCustomCastingTests.cs`)
- `Decorator_ReadsColumnMetadata_AfterResultExhausted` — through the library's decorator (`GetName`/`GetFieldType`/`FieldCount` after exhaustion).
- `RawReader_GetSchemaTable_AfterResultExhausted_DoesNotThrow` — mirrors #332's exact `GetSchemaTable()` call on the raw `DuckDBDataReader`.

**Verified as genuine guards:** temporarily reverting to 1.5.2 makes both tests throw `System.IndexOutOfRangeException` (the raw one at exactly `DuckDB.NET.Data.DuckDBDataReader.GetSchemaTable()`); on 1.5.5 both pass.

## Regressions

**Zero.** Full suite **60/60** on net8.0 and net10.0 (58 existing + 2 new).

## Out of scope (pre-existing, flagged not fixed)
- `DbDataReaderCustomCasting` does not override `GetSchemaTable()`, so calling it on the decorator throws `NotSupportedException` on every version.
- Transitive `NU1903` high-severity advisory in `SQLitePCLRaw.lib.e_sqlite3` (via `SourceGear.sqlite3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
