### PR TITLE
Fix CI release job: grant contents:write + define new_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
     needs: [build-and-test, security-scan]
     # Only run release when PR is merged into main (push to main after PR merge)
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # GITHUB_TOKEN needs write access to push tags and create the GitHub Release.
+    # The repo default is read-only, which caused the tag push to fail with 403.
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -139,8 +143,13 @@ jobs:
             NET10_VERSION="10.0.$((PATCH + 1))"
           fi
 
+          # Single version used for the GitHub Release tag, zip name and version file.
+          # Track the net10 line as the primary going-forward framework.
+          NEW_VERSION="$NET10_VERSION"
+
           echo "net8_version=$NET8_VERSION" >> $GITHUB_OUTPUT
           echo "net10_version=$NET10_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Net8 version: $NET8_VERSION"
           echo "Net10 version: $NET10_VERSION"
 


### PR DESCRIPTION
## Problem

The **Create Release Package** job in `ci.yml` fails on every push to `main` at the **Create and push Git tags** step:

```
remote: Permission to EnergyExemplar/EnergyExemplar.EFCore.Duckdb.Extensions.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

(Seen on the run for the #30 merge: `.../actions/runs/32715598558`.)

## Root cause

1. **403 on tag push** — the repo's default workflow permission is **read-only** (`default_workflow_permissions: "read"`), and `ci.yml` declared **no `permissions:` block**. So the freshly-minted `GITHUB_TOKEN` is authenticated as `github-actions[bot]` but not *authorized* to write — it's a 403 (authorization), not a 401 (expiry/auth). Nothing to do with token expiry: `GITHUB_TOKEN` is minted fresh per run.

2. **Undefined `new_version` output** — a second latent bug that breaks the job even after the 403 is fixed. The `get_version` step outputs only `net8_version` and `net10_version`, but `steps.get_version.outputs.new_version` is referenced in **7 places** (release tag, zip name, version file, artifact name). `gh release create` would run with an empty tag and fail. This has never surfaced because the job always died at the earlier 403.

## Fix

- Add `permissions: contents: write` **scoped to the `release` job** (least privilege — no repo-admin setting change, other jobs stay read-only).
- Emit `new_version` from the `get_version` step, set to the **net10** version line (the primary going-forward framework), so the release tag / zip / version file resolve consistently.

## Verification

- `ci.yml` re-parsed as valid YAML; `release.permissions == {contents: write}`.
- The release job only runs on push to `main`, so it will next execute — and should complete past the tag push — when this PR merges.

## Assumption worth a look

`new_version` is unified to the **net10** version. If you'd rather the single GitHub Release track the net8 line (or cut two separate releases), say so and I'll adjust — this is the one judgment call in the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
