### PR TITLE
Fix CI release job: publish requires explicit target framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,9 @@ jobs:
         run: mkdir -p ./artifacts
 
       - name: Publish application
-        run: dotnet publish --no-build --configuration Release --output ../publish/
+        # The project multi-targets net8.0;net10.0, so dotnet publish requires an
+        # explicit framework. Publish net10.0 to match the primary release version.
+        run: dotnet publish EnergyExemplar.EFCore.Duckdb.Extensions.csproj --no-build --configuration Release --framework net10.0 --output ../publish/
         working-directory: ./Source
 
       - name: Create version info file


### PR DESCRIPTION
Third latent bug in the release job, masked until the 403 and new_version fixes let the job reach it. `dotnet publish` on the multi-TFM project (net8.0;net10.0) fails without `--framework`. Publish net10.0 explicitly (matches the primary release version). Validated locally.

Prior fixes: #31 (contents:write + new_version). After merge, tags 8.0.0/10.0.0 now exist; this run will cut 8.0.1/10.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)